### PR TITLE
Missing type when sending text message

### DIFF
--- a/client/scripts/controllers/chat-detail.controller.js
+++ b/client/scripts/controllers/chat-detail.controller.js
@@ -59,6 +59,7 @@ function ChatDetailCtrl ($scope, $stateParams, $ionicScrollDelegate, $timeout, $
 
     $meteor.call('newMessage', {
       text: $scope.data.message,
+      type: 'text',
       chatId: chatId
     });
 


### PR DESCRIPTION
missing field `type` in (chat-detail.controller.js) sendMessage function, which will cause wrong style of text message in chat-detail.html
